### PR TITLE
style: small change to make images contain

### DIFF
--- a/components/grid/tile.tsx
+++ b/components/grid/tile.tsx
@@ -72,7 +72,7 @@ export function GridTileImage({
           >
             {props.src ? (
               // eslint-disable-next-line jsx-a11y/alt-text -- `alt` is inherited from `props`, which is being enforced with TypeScript
-              <Image className={clsx('h-full w-full object-cover object-center')} {...props} />
+              <Image className={clsx('h-full w-full object-contain object-center')} {...props} />
             ) : (
               <div
                 className="flex h-full w-full items-center justify-center text-gray-400"
@@ -157,7 +157,7 @@ export const TileImage = ({
     >
       {props.src ? (
         // eslint-disable-next-line jsx-a11y/alt-text -- `alt` is inherited from `props`, which is being enforced with TypeScript
-        <Image className={clsx('h-full w-full object-cover object-center')} {...props} />
+        <Image className={clsx('h-full w-full object-contain object-center')} {...props} />
       ) : (
         <div
           className="flex h-full w-full items-center justify-center text-gray-400"


### PR DESCRIPTION
Small change per request from Steve to shift images so that some of the images weren't getting cutoff. Think `contain` should do the trick here. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated image display mode in grid tiles from `object-cover` to `object-contain` to improve visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->