### PR TITLE
feat: simple product redirect for old product urls

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,12 @@ module.exports = {
         source: '/password',
         destination: '/',
         permanent: true
+      },
+      // Redirect all product pages to the equivalent collection year
+      {
+        source: '/:partType/:make/:model/:year/:product',
+        destination: '/:partType/:make/:model/:year',
+        permanent: true
       }
     ];
   }


### PR DESCRIPTION
This is to handle products, not plps/collections. It takes anything after the year and sends it back to the year.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a redirection rule for product pages to the equivalent collection year pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->